### PR TITLE
fix: preserve user config when validating port settings

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -108,15 +108,16 @@ func create() {
 }
 
 // Validate the configuration. This is to ensure compatibility with earlier versions.
+// Instead of deleting the user's config file (which loses settings like authentication),
+// set default values for any missing fields.
 func validate() error {
-	if viper.GetInt("port.http") > 0 && viper.GetInt("port.https") > 0 {
-		return nil
+	if viper.GetInt("port.http") <= 0 {
+		viper.Set("port.http", defaultConfig.Port.Http)
+		log.Println("port.http was missing or invalid, using default")
 	}
-
-	_ = os.Remove("/etc/kvm/server.yaml")
-	log.Println("delete empty configuration file")
-
-	create()
-
-	return readByDefault()
+	if viper.GetInt("port.https") <= 0 {
+		viper.Set("port.https", defaultConfig.Port.Https)
+		log.Println("port.https was missing or invalid, using default")
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Fix `validate()` in `server/config/config.go` that silently deletes and recreates `server.yaml` when port values are missing or invalid
- This caused user settings (like `authentication: "disable"`) to be lost on restart
- Now sets default values for missing port fields without deleting the config file

## Root Cause

The `validate()` function checked if both `port.http` and `port.https` were > 0. If not (e.g., older config format), it deleted the entire config file and recreated it with defaults. This reset all user-customized settings including authentication mode.

## Changes

- `server/config/config.go`: Replace file deletion logic with field-level default value assignment

## Related

- Stella-IT/NanoKVM#4
- Upstream: sipeed/NanoKVM#506