### PR TITLE
fix: add IP-based login rate limiting

### DIFF
--- a/server/middleware/rate_limit.go
+++ b/server/middleware/rate_limit.go
@@ -1,0 +1,87 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	maxLoginFailures   = 5
+	loginBlockDuration = 5 * time.Minute
+	cleanupInterval    = 10 * time.Minute
+)
+
+type loginAttempt struct {
+	failures  int
+	blockedAt time.Time
+}
+
+var (
+	loginAttempts   = make(map[string]*loginAttempt)
+	loginAttemptsMu sync.Mutex
+)
+
+func init() {
+	go cleanupLoginAttempts()
+}
+
+func LoginRateLimit() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+
+		loginAttemptsMu.Lock()
+		attempt, exists := loginAttempts[ip]
+		if exists && attempt.failures >= maxLoginFailures {
+			if time.Since(attempt.blockedAt) < loginBlockDuration {
+				loginAttemptsMu.Unlock()
+				c.JSON(http.StatusTooManyRequests, gin.H{
+					"code": -1,
+					"msg":  "too many login attempts, try again later",
+				})
+				c.Abort()
+				return
+			}
+			delete(loginAttempts, ip)
+		}
+		loginAttemptsMu.Unlock()
+
+		c.Next()
+	}
+}
+
+func RecordLoginFailure(ip string) {
+	loginAttemptsMu.Lock()
+	defer loginAttemptsMu.Unlock()
+
+	attempt, exists := loginAttempts[ip]
+	if !exists {
+		loginAttempts[ip] = &loginAttempt{failures: 1, blockedAt: time.Now()}
+		return
+	}
+	attempt.failures++
+	attempt.blockedAt = time.Now()
+}
+
+func ResetLoginAttempts(ip string) {
+	loginAttemptsMu.Lock()
+	defer loginAttemptsMu.Unlock()
+
+	delete(loginAttempts, ip)
+}
+
+func cleanupLoginAttempts() {
+	for {
+		time.Sleep(cleanupInterval)
+
+		loginAttemptsMu.Lock()
+		for ip, attempt := range loginAttempts {
+			if time.Since(attempt.blockedAt) > loginBlockDuration {
+				delete(loginAttempts, ip)
+			}
+		}
+		loginAttemptsMu.Unlock()
+	}
+}

--- a/server/router/auth.go
+++ b/server/router/auth.go
@@ -10,7 +10,7 @@ import (
 func authRouter(r *gin.Engine) {
 	service := auth.NewService()
 
-	r.POST("/api/auth/login", service.Login) // login
+	r.POST("/api/auth/login", middleware.LoginRateLimit(), service.Login) // login
 
 	api := r.Group("/api").Use(middleware.CheckToken())
 

--- a/server/service/auth/login.go
+++ b/server/service/auth/login.go
@@ -24,12 +24,14 @@ func (s *Service) Login(c *gin.Context) {
 	}
 
 	if err := proto.ParseFormRequest(c, &req); err != nil {
+		middleware.RecordLoginFailure(c.ClientIP())
 		time.Sleep(3 * time.Second)
 		rsp.ErrRsp(c, -1, "invalid parameters")
 		return
 	}
 
 	if ok := CompareAccount(req.Username, req.Password); !ok {
+		middleware.RecordLoginFailure(c.ClientIP())
 		time.Sleep(2 * time.Second)
 		rsp.ErrRsp(c, -2, "invalid username or password")
 		return
@@ -41,6 +43,8 @@ func (s *Service) Login(c *gin.Context) {
 		rsp.ErrRsp(c, -3, "generate token failed")
 		return
 	}
+
+	middleware.ResetLoginAttempts(c.ClientIP())
 
 	rsp.OkRspWithData(c, &proto.LoginRsp{
 		Token: token,


### PR DESCRIPTION
## Summary

- Add `LoginRateLimit()` middleware to block brute force login attempts
- Block IP after 5 failed attempts for 5 minutes
- Track failures per client IP with automatic cleanup goroutine
- Reset counter on successful login
- Existing `time.Sleep` delays are preserved for additional protection

## Changes

- `server/middleware/rate_limit.go`: New rate limiting middleware with `RecordLoginFailure()` and `ResetLoginAttempts()` helpers
- `server/service/auth/login.go`: Record failures on invalid params/credentials, reset on success
- `server/router/auth.go`: Apply `LoginRateLimit()` middleware to login endpoint

## Related

- Stella-IT/NanoKVM#3
- Upstream: sipeed/NanoKVM#444