### PR TITLE
fix: validate WebSocket origin and guard against empty messages

### DIFF
--- a/server/middleware/websocket.go
+++ b/server/middleware/websocket.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"net/http"
+	"net/url"
+
+	log "github.com/sirupsen/logrus"
+
+	"NanoKVM-Server/config"
+)
+
+// CheckWebSocketOrigin validates the Origin header on WebSocket upgrade requests.
+// Allows non-browser clients (no Origin header) and same-host browser requests.
+// When authentication is disabled, all origins are allowed.
+func CheckWebSocketOrigin(r *http.Request) bool {
+	conf := config.GetInstance()
+	if conf.Authentication == "disable" {
+		return true
+	}
+
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	parsed, err := url.Parse(origin)
+	if err != nil {
+		log.Warnf("websocket: invalid origin header: %s", origin)
+		return false
+	}
+
+	if parsed.Host != r.Host {
+		log.Warnf("websocket: origin mismatch: origin=%s, host=%s", parsed.Host, r.Host)
+		return false
+	}
+
+	return true
+}

--- a/server/service/stream/direct/h264.go
+++ b/server/service/stream/direct/h264.go
@@ -1,20 +1,19 @@
 package direct
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
+
+	"NanoKVM-Server/middleware"
 )
 
 var (
 	streamer = newStreamer()
 	upgrader = websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
+		CheckOrigin: middleware.CheckWebSocketOrigin,
 	}
 )
 

--- a/server/service/stream/h264/h264.go
+++ b/server/service/stream/h264/h264.go
@@ -2,7 +2,7 @@ package h264
 
 import (
 	"NanoKVM-Server/config"
-	"net/http"
+	"NanoKVM-Server/middleware"
 	"sync"
 	"time"
 
@@ -14,9 +14,7 @@ import (
 
 var (
 	upgrader = websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
+		CheckOrigin: middleware.CheckWebSocketOrigin,
 	}
 	trackMap  = make(map[*websocket.Conn]*webrtc.TrackLocalStaticSample)
 	isSending = false

--- a/server/service/stream/webrtc/h264.go
+++ b/server/service/stream/webrtc/h264.go
@@ -2,7 +2,7 @@ package webrtc
 
 import (
 	"NanoKVM-Server/config"
-	"net/http"
+	"NanoKVM-Server/middleware"
 	"sync"
 	"time"
 
@@ -15,9 +15,7 @@ import (
 
 var (
 	upgrader = websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
+		CheckOrigin: middleware.CheckWebSocketOrigin,
 	}
 	globalManager *WebRTCManager
 	managerOnce   sync.Once

--- a/server/service/vm/terminal.go
+++ b/server/service/vm/terminal.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"encoding/json"
-	"net/http"
 	"os"
 	"os/exec"
 	"time"
@@ -11,6 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
+
+	"NanoKVM-Server/middleware"
 )
 
 const (
@@ -26,9 +27,7 @@ type WinSize struct {
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  maxMessageSize,
 	WriteBufferSize: maxMessageSize,
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
+	CheckOrigin:     middleware.CheckWebSocketOrigin,
 }
 
 func (s *Service) Terminal(c *gin.Context) {

--- a/server/service/ws/client.go
+++ b/server/service/ws/client.go
@@ -52,6 +52,10 @@ func (c *Client) Read() error {
 
 		log.Debugf("received message %d: %v", messageType, data)
 
+		if len(data) == 0 {
+			continue
+		}
+
 		switch data[0] {
 		case Heartbeat:
 			c.UpdateHeartbeat()

--- a/server/service/ws/service.go
+++ b/server/service/ws/service.go
@@ -1,11 +1,11 @@
 package ws
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
+
+	"NanoKVM-Server/middleware"
 )
 
 type Service struct{}
@@ -13,9 +13,7 @@ type Service struct{}
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
+	CheckOrigin:     middleware.CheckWebSocketOrigin,
 }
 
 func NewService() *Service {


### PR DESCRIPTION
## Summary

- Add `CheckWebSocketOrigin()` middleware to validate Origin header on all WebSocket upgrade requests
- Apply to all 5 WebSocket upgraders: HID (keyboard/mouse), terminal, h264, webrtc, direct stream
- Add empty data length check in `ws/client.go` to prevent index out of bounds panic

## Attack Chain (before fix)

1. User logs into NanoKVM (JWT cookie set in browser)
2. User visits malicious website
3. Malicious site opens WebSocket to KVM — browser includes JWT cookie automatically
4. Attacker can: send keyboard/mouse commands, access root shell, or crash server with empty message

## Changes

- `server/middleware/websocket.go` (new): Shared `CheckWebSocketOrigin` function — validates Origin matches request Host, allows non-browser clients, bypasses when auth disabled
- `server/service/ws/service.go`: Use shared CheckOrigin
- `server/service/vm/terminal.go`: Use shared CheckOrigin
- `server/service/stream/webrtc/h264.go`: Use shared CheckOrigin
- `server/service/stream/h264/h264.go`: Use shared CheckOrigin
- `server/service/stream/direct/h264.go`: Use shared CheckOrigin
- `server/service/ws/client.go`: Add `len(data) == 0` guard before `data[0]` access

## Related

- Stella-IT/NanoKVM#14