### PR TITLE
feat: send hostname in DHCP requests

### DIFF
--- a/kvmapp/system/init.d/S30eth
+++ b/kvmapp/system/init.d/S30eth
@@ -43,7 +43,7 @@ start() {
         done < /boot/eth.nodhcp
 
         ip a show dev eth0 | grep inet > /dev/null || {
-            udhcpc -i eth0 -t 3 -T 1 -A 5 -b $HOSTNAME_OPT -p /run/udhcpc.eth0.pid &>/dev/null
+            udhcpc -i eth0 -t 3 -T 1 -A 5 -b -O 121 $HOSTNAME_OPT -p /run/udhcpc.eth0.pid &>/dev/null
             ip a show dev eth0 | grep inet > /dev/null
         } || {
             inet=$RESERVE_INET
@@ -51,7 +51,7 @@ start() {
             ip a add "$inet" brd + dev eth0
         } || exit 1
     else
-        udhcpc -i eth0 -t 10 -T 1 -A 5 -b $HOSTNAME_OPT -p /run/udhcpc.eth0.pid &
+        udhcpc -i eth0 -t 10 -T 1 -A 5 -b -O 121 $HOSTNAME_OPT -p /run/udhcpc.eth0.pid &
     fi
 }
 

--- a/kvmapp/system/init.d/S30wifi
+++ b/kvmapp/system/init.d/S30wifi
@@ -77,7 +77,7 @@ start() {
     wpa_passphrase "$ssid" "$pass" >>/etc/wpa_supplicant.conf
     wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant.conf
     if [ ! -e /boot/wifi.nodhcp ]; then
-        (udhcpc -i wlan0 -t 10 -T 1 -A 5 -b $HOSTNAME_OPT -p /run/udhcpc.wlan0.pid) &
+        (udhcpc -i wlan0 -t 10 -T 1 -A 5 -b -O 121 $HOSTNAME_OPT -p /run/udhcpc.wlan0.pid) &
     fi
 }
 


### PR DESCRIPTION
## Summary

- Read `/etc/hostname` at boot and pass it to `udhcpc` via `-x hostname:` option
- Applied to all 3 udhcpc invocations: S30eth (static IP fallback, normal DHCP) and S30wifi
- Gracefully skipped when `/etc/hostname` doesn't exist or is empty
- Uses `-x hostname:` instead of `-F` for better compatibility with various DHCP server implementations (e.g. Mikrotik)

## Changed files

- `kvmapp/system/init.d/S30eth` - ethernet init script
- `kvmapp/system/init.d/S30wifi` - wifi init script

## Test plan

- [ ] Set hostname via `/etc/hostname`, reboot, verify DHCP server shows hostname
- [ ] Remove `/etc/hostname`, reboot, verify udhcpc still works without hostname
- [ ] Test with both ethernet and wifi connections
- [ ] Verify hostname appears in router's DHCP lease table