### PR TITLE
fix: don't expose eMMC as USB mass storage when no image is mounted

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -106,17 +106,15 @@ start_usb_dev(){
             fi
             echo "NanoKVM USB Mass Storage0520" > functions/mass_storage.disk0/lun.0/inquiry_string
             disk=$(cat /boot/usb.disk0)
-            if [ -z "${disk}" ]
+            if [ -n "${disk}" ]
             then
-                    # if [ ! -e /mnt/usbdisk.img ]
-                    # then
-                    #         fallocate -l 8G /mnt/usbdisk.img
-                    #         mkfs.vfat /mnt/usbdisk.img
-                    # fi
-                    echo /dev/mmcblk0p3 > functions/mass_storage.disk0/lun.0/file
-            else
                     cat /boot/usb.disk0 > functions/mass_storage.disk0/lun.0/file
             fi
+            # When usb.disk0 is empty, no backing file is set. The device
+            # reports "no media" (removable=1). Previously this defaulted to
+            # /dev/mmcblk0p3, exposing the NanoKVM's raw eMMC partition as a
+            # USB disk — causing Legacy BIOS systems to hang during boot.
+            # See: https://github.com/sipeed/NanoKVM/issues/633
     fi
 
     ls /sys/class/udc/ | cat > UDC


### PR DESCRIPTION
## Summary

- When `usb.disk0` is empty, the USB gadget now reports "no media" instead of exposing `/dev/mmcblk0p3`
- Prevents Legacy BIOS systems from hanging during boot when the raw eMMC partition was exposed as a USB disk
- `GetMountedImage` API treats `/dev/mmcblk0p3` as unmounted for backward compatibility

Cherry-picked from upstream PR sipeed/NanoKVM#741 (author: @MagnaCapax)

## Test plan

- [ ] Verify Legacy BIOS systems no longer hang with NanoKVM connected
- [ ] Verify image mount/unmount still works correctly
- [ ] Verify `GetMountedImage` API returns empty string when no image mounted