### PR TITLE
feat: derive USB serial number from SoC hardware UID

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -24,7 +24,13 @@ start_usb_dev(){
         echo 0x1009 > idProduct
     fi
     mkdir strings/0x409
-    echo '0123456789ABCDEF' > strings/0x409/serialnumber
+    if [ -f /sys/class/cvi-base/base_uid ]; then
+        _uid=$(awk '{print $2}' /sys/class/cvi-base/base_uid)
+        _serial=$(echo "$_uid" | tr -d '_')
+        echo "$_serial" > strings/0x409/serialnumber
+    else
+        echo '0123456789ABCDEF' > strings/0x409/serialnumber
+    fi
     echo 'sipeed' > strings/0x409/manufacturer
     echo 'NanoKVM' > strings/0x409/product
 


### PR DESCRIPTION
## Summary

- Read unique hardware UID from `/sys/class/cvi-base/base_uid` and use it as USB serial number
- Falls back to default `0123456789ABCDEF` if UID file is unavailable
- Enables identifying individual NanoKVM devices when multiple are connected to the same host

Cherry-picked from upstream PR sipeed/NanoKVM#746 (author: @JakeHillion)

## Test plan

- [ ] Verify USB serial number matches SoC UID on supported hardware
- [ ] Verify fallback works when `/sys/class/cvi-base/base_uid` is missing
- [ ] Verify multiple NanoKVM devices show distinct serial numbers