### PR TITLE
fix: request DHCP classless static routes (option 121)

### DIFF
--- a/kvmapp/system/init.d/S30eth
+++ b/kvmapp/system/init.d/S30eth
@@ -39,7 +39,7 @@ start() {
         done < /boot/eth.nodhcp
 
         ip a show dev eth0 | grep inet > /dev/null || {
-            udhcpc -i eth0 -t 3 -T 1 -A 5 -b -p /run/udhcpc.eth0.pid &>/dev/null
+            udhcpc -i eth0 -t 3 -T 1 -A 5 -b -O 121 -p /run/udhcpc.eth0.pid &>/dev/null
             ip a show dev eth0 | grep inet > /dev/null
         } || {
             inet=$RESERVE_INET
@@ -47,7 +47,7 @@ start() {
             ip a add "$inet" brd + dev eth0
         } || exit 1
     else
-        udhcpc -i eth0 -t 10 -T 1 -A 5 -b -p /run/udhcpc.eth0.pid &
+        udhcpc -i eth0 -t 10 -T 1 -A 5 -b -O 121 -p /run/udhcpc.eth0.pid &
     fi
 }
 


### PR DESCRIPTION
## Summary

- Add `-O 121` flag to `udhcpc` calls in S30eth to request DHCP option 121
- Enables network administrators to push classless static routes to the device
- Useful for isolated network segments where specific routing is needed without default gateways

Cherry-picked from upstream PR sipeed/NanoKVM#749 (author: @phaidros7)

## Test plan

- [ ] Verify DHCP lease still works normally
- [ ] Verify option 121 routes are applied when DHCP server pushes them
- [ ] Verify no regression on networks without option 121