### PR TITLE
fix: replace hardcoded China DNS with global public DNS

### DIFF
--- a/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
@@ -174,15 +174,11 @@ void new_app_init(void)
 void build_complete_resolv(void)
 {
 	FILE *fp = NULL;
-	// fp = fopen("/boot/resolv.conf", "w+");
 	fp = fopen("/boot/resolv.conf", "w");
-	// 阿里: 223.5.5.5
-	// 腾讯: 119.29.29.29
-	fprintf(fp, "nameserver 192.168.0.1\nnameserver 8.8.4.4\nnameserver 8.8.8.8\nnameserver 114.114.114.114\nnameserver 119.29.29.29\nnameserver 223.5.5.5");
+	fprintf(fp, "nameserver 1.1.1.1\nnameserver 8.8.8.8\nnameserver 8.8.4.4\n");
 	fclose(fp);
-	system("rm -rf /etc/resolv.conf");
-	system("cp -vf /etc/resolv.conf /etc/resolv.conf.old");
-	system("cp -vf /boot/resolv.conf /etc/resolv.conf");
+	system("cp -f /etc/resolv.conf /etc/resolv.conf.old 2>/dev/null");
+	system("cp -f /boot/resolv.conf /etc/resolv.conf");
 }
 
 void new_img_init(void)


### PR DESCRIPTION
## Summary

- Remove China-specific DNS servers (114.114.114.114, 119.29.29.29, 223.5.5.5) from `build_complete_resolv()`
- Replace with Cloudflare (1.1.1.1) and Google (8.8.8.8, 8.8.4.4) as universal fallback
- Fix bug: old code did `rm -rf /etc/resolv.conf` then `cp /etc/resolv.conf /etc/resolv.conf.old` (backup after delete)
- This function only runs on new image initialization (`kvm_new_img` flag)

Addresses Stella-IT/NanoKVM#1

## Changed files

- `support/sg2002/kvm_system/main/lib/system_init/system_init.cpp`

## Test plan

- [ ] Flash new image, verify `/etc/resolv.conf` contains only 1.1.1.1, 8.8.8.8, 8.8.4.4
- [ ] Verify DHCP-provided DNS still overrides after network init
- [ ] Verify DNS resolution works on first boot